### PR TITLE
修复调用千帆非chat类型模型url转换报错问题

### DIFF
--- a/appbuilder/core/components/llms/base.py
+++ b/appbuilder/core/components/llms/base.py
@@ -240,8 +240,8 @@ class CompletionBaseComponent(Component):
 
     def _convert_cloudhub_url(self, qianfan_url: str) -> str:
         """将千帆url转换为AppBuilder url"""
-        qianfan_url_prefix = "rpc/2.0/ai_custom/v1/wenxinworkshop/chat"
-        cloudhub_url_prefix = "rpc/2.0/cloud_hub/v1/bce/wenxinworkshop/ai_custom/v1/chat"
+        qianfan_url_prefix = "rpc/2.0/ai_custom/v1/wenxinworkshop"
+        cloudhub_url_prefix = "rpc/2.0/cloud_hub/v1/bce/wenxinworkshop/ai_custom/v1"
         index = str.find(qianfan_url, qianfan_url_prefix)
         if index == -1:
             raise ValueError(f"{qianfan_url} is not a valid qianfan url")

--- a/appbuilder/core/components/llms/base.py
+++ b/appbuilder/core/components/llms/base.py
@@ -28,7 +28,7 @@ from typing import Dict, List, Optional, Any
 
 from appbuilder.core.component import ComponentArguments
 from appbuilder.core._exception import AppBuilderServerException
-from appbuilder.utils.model_util import Models, model_name_mapping
+from appbuilder.core.utils import get_model_url
 from appbuilder.utils.sse_util import SSEClient
 
 
@@ -189,7 +189,7 @@ class CompletionBaseComponent(Component):
         super().__init__(meta=meta, secret_key=secret_key, gateway=gateway)
 
         self.model_name = model
-        self.model_url = self.get_model_url()
+        self.model_url = get_model_url(client=self.http_client, model_name=model)
         if not self.model_name and not self.model_url:
             raise ValueError("model_name or model_url must be provided")
         self.version = self.version
@@ -242,33 +242,6 @@ class CompletionBaseComponent(Component):
             raise AppBuilderServerException(service_err_code=response.error_no, service_err_message=response.error_msg)
 
         return response.to_message()
-
-    def get_model_url(self) -> str:
-        """根据名称获取模型请求url"""
-        origin_name = self.model_name
-        for key, value in model_name_mapping.items():
-            if origin_name == value:
-                origin_name = key
-                break
-
-        client = self.http_client
-        response = Models(client.secret_key, client.gateway).list()
-        for model in itertools.chain(response.result.common, response.result.custom):
-            if model.name == origin_name:
-                return self._convert_cloudhub_url(model.url)
-
-        raise ValueError(f"Model[{self.model_name}] not available! "
-                         f"You can query available models through: appbuilder.get_model_list()")
-
-    def _convert_cloudhub_url(self, qianfan_url: str) -> str:
-        """将千帆url转换为AppBuilder url"""
-        qianfan_url_prefix = "rpc/2.0/ai_custom/v1/wenxinworkshop"
-        cloudhub_url_prefix = "rpc/2.0/cloud_hub/v1/bce/wenxinworkshop/ai_custom/v1"
-        index = str.find(qianfan_url, qianfan_url_prefix)
-        if index == -1:
-            raise ValueError(f"{qianfan_url} is not a valid qianfan url")
-        url_suffix = qianfan_url[index + len(qianfan_url_prefix):]
-        return "{}/{}{}".format(self.http_client.gateway, cloudhub_url_prefix, url_suffix)
 
     def get_compeliton_params(self, specific_inputs, model_config_inputs):
         """获取模型请求参数"""

--- a/appbuilder/utils/model_util.py
+++ b/appbuilder/utils/model_util.py
@@ -192,18 +192,20 @@ class Models:
      """
 
     def __init__(self,
+                 client: HTTPClient = None,
                  secret_key: Optional[str] = None,
                  gateway: str = ""
                  ):
         r"""Models初始化方法.
 
             参数:
+                client(obj:`HTTPClient`): 客户端实例，用于发送请求。
                 secret_key(str,可选): 用户鉴权token, 默认从环境变量中获取: os.getenv("APPBUILDER_TOKEN", "").
                 gateway(str, 可选): 后端网关服务地址，默认从环境变量中获取: os.getenv("GATEWAY_URL", "")
             返回：
                 无
         """
-        self.http_client = HTTPClient(secret_key, gateway)
+        self.http_client = client or HTTPClient(secret_key, gateway)
 
     def list(self, request: GetModelListRequest = None, timeout: float = None,
              retry: int = 0) -> GetModelListResponse:


### PR DESCRIPTION
1、修复调用千帆非chat类型模型url转换报错问题
2、将url映射代码提取出来供其它模块（embedding）引用