### PR TITLE
【GoSDK】支持使用 SDKConfig 传入自定义的 HTTP Client，以 满足 MLT 的需求

### DIFF
--- a/go/appbuilder/agent_builder.go
+++ b/go/appbuilder/agent_builder.go
@@ -36,13 +36,17 @@ func NewAgentBuilder(appID string, config *SDKConfig) (*AgentBuilder, error) {
 	if config == nil {
 		return nil, errors.New("config is nil")
 	}
-	return &AgentBuilder{appID: appID, sdkConfig: config, client: &http.Client{Timeout: 300 * time.Second}}, nil
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 300 * time.Second}
+	}
+	return &AgentBuilder{appID: appID, sdkConfig: config, client: client}, nil
 }
 
 type AgentBuilder struct {
 	appID     string
 	sdkConfig *SDKConfig
-	client    *http.Client
+	client    HTTPClient
 }
 
 func (t *AgentBuilder) CreateConversation() (string, error) {

--- a/go/appbuilder/app_builder_client.go
+++ b/go/appbuilder/app_builder_client.go
@@ -35,13 +35,21 @@ func NewAppBuilderClient(appID string, config *SDKConfig) (*AppBuilderClient, er
 	if config == nil {
 		return nil, errors.New("config is nil")
 	}
-	return &AppBuilderClient{appID: appID, sdkConfig: config, client: &http.Client{Timeout: 300 * time.Second}}, nil
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 300 * time.Second}
+	}
+	return &AppBuilderClient{appID: appID, sdkConfig: config, client: client}, nil
 }
 
 type AppBuilderClient struct {
 	appID     string
 	sdkConfig *SDKConfig
-	client    *http.Client
+	client    HTTPClient
+}
+
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
 }
 
 func (t *AppBuilderClient) CreateConversation() (string, error) {

--- a/go/appbuilder/config.go
+++ b/go/appbuilder/config.go
@@ -48,6 +48,7 @@ type SDKConfig struct {
 	ConsoleOpenAPIVersion string
 	ConsoleOpenAPIPrefix  string
 	SecretKey             string
+	HTTPClient            HTTPClient // custom HTTP Client, optional
 	logger                zerolog.Logger
 }
 

--- a/go/appbuilder/dataset.go
+++ b/go/appbuilder/dataset.go
@@ -31,12 +31,16 @@ func NewDataset(config *SDKConfig) (*Dataset, error) {
 	if config == nil {
 		return nil, errors.New("invalid config")
 	}
-	return &Dataset{sdkConfig: config, client: &http.Client{Timeout: 60 * time.Second}}, nil
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &Dataset{sdkConfig: config, client: client}, nil
 }
 
 type Dataset struct {
 	sdkConfig *SDKConfig
-	client    *http.Client
+	client    HTTPClient
 }
 
 func (t *Dataset) Create(name string) (string, error) {

--- a/go/appbuilder/rag.go
+++ b/go/appbuilder/rag.go
@@ -32,13 +32,17 @@ func NewRAG(appID string, config *SDKConfig) (*RAG, error) {
 	if config == nil {
 		return nil, errors.New("invalid config")
 	}
-	return &RAG{appID: appID, sdkConfig: config, client: &http.Client{Timeout: 500 * time.Second}}, nil
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 500 * time.Second}
+	}
+	return &RAG{appID: appID, sdkConfig: config, client: client}, nil
 }
 
 type RAG struct {
 	appID     string
 	sdkConfig *SDKConfig
-	client    *http.Client
+	client    HTTPClient
 }
 
 func (t *RAG) Run(conversationID string, query string, stream bool) (RAGIterator, error) {


### PR DESCRIPTION
SDKConfig 新增一个可选属性 HTTPClient，当不传入该值的时候，会使用默认Client（和原来保持一致）。

在此之前，SDK 是直接使用标准库的 *http.Client, 在发送请求的时候，如果使用 SDK 的用户想要打印访问日志，统计可用性、添加 Trace 等是没法做到的。
若用户有 Log、Metrics、Trace 等需求，只需要传入自定义的 Client，通过此自定义 Client 实现这些额外的功能。