### PR TITLE
python-sdk 新增知识库、知识库文档、切片增删改查等OpenAPI

### DIFF
--- a/appbuilder/__init__.py
+++ b/appbuilder/__init__.py
@@ -122,7 +122,7 @@ from appbuilder.core.console.appbuilder_client.appbuilder_client import AppBuild
 from appbuilder.core.console.appbuilder_client.appbuilder_client import AgentBuilder
 from appbuilder.core.console.appbuilder_client.appbuilder_client import get_app_list
 from appbuilder.core.console.knowledge_base.knowledge_base import KnowledgeBase
-from appbuilder.core.console.knowledge_base.data_class import CustomProcessRule
+from appbuilder.core.console.knowledge_base.data_class import CustomProcessRule, DocumentSource, DocumentChoices, DocumentChunker, DocumentSeparator, DocumentPattern, DocumentProcessOption
 
 from .core._exception import (
     BadRequestException,
@@ -206,6 +206,12 @@ __all__ = [
 
     "KnowledgeBase",
     "CustomProcessRule",
+    "DocumentSource",
+    "DocumentChoices",
+    "DocumentChunker",
+    "DocumentSeparator",
+    "DocumentPattern",
+    "DocumentProcessOption",
 
     "assistant",
     "StreamRunContext",

--- a/appbuilder/core/_session.py
+++ b/appbuilder/core/_session.py
@@ -31,8 +31,13 @@ class InnerSession(requests.sessions.Session):
         Generate cURL command from prepared request object.
         """
         curl = "curl -X {0} -L '{1}' \\\n".format(request.method, request.url)
-        headers = ["-H '{0}: {1}' \\".format(k, v)
-                   for k, v in request.headers.items() if k != 'Content-Length']
+
+        headers = [
+            "-H '{0}: {1}' \\".format(k, v)
+            for k, v in request.headers.items()
+            if k != "Content-Length"
+        ]
+
         if headers:
             headers[-1] = headers[-1].rstrip(" \\")
         curl += "\n".join(headers)

--- a/appbuilder/core/console/knowledge_base/__init__.py
+++ b/appbuilder/core/console/knowledge_base/__init__.py
@@ -13,4 +13,12 @@
 # limitations under the License.
 
 from .knowledge_base import KnowledgeBase
-from .data_class import CustomProcessRule
+from .data_class import (
+    CustomProcessRule,
+    DocumentSource,
+    DocumentProcessOption,
+    DocumentChoices,
+    DocumentSeparator,
+    DocumentPattern,
+    DocumentChunker,
+)

--- a/appbuilder/core/console/knowledge_base/data_class.py
+++ b/appbuilder/core/console/knowledge_base/data_class.py
@@ -76,8 +76,8 @@ class KnowledgeBaseGetDocumentsListRequest(BaseModel):
 
 
 class DocumentMeta(BaseModel):
-    source: str = Field(None, description="文档来源")
-    file_id: str = Field(None, description="文档对应的文件ID")
+    source: Optional[str] = Field(None, description="文档来源")
+    file_id: Optional[str] = Field(None, description="文档对应的文件ID")
 
 
 class Document(BaseModel):

--- a/appbuilder/core/console/knowledge_base/data_class.py
+++ b/appbuilder/core/console/knowledge_base/data_class.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from pydantic import Field
 from typing import Union
 from typing import Optional
+import datetime
 
 
 class KnowledgeBaseUploadFileResponse(BaseModel):
@@ -119,7 +120,7 @@ class KnowledgeBaseGetDetailRequest(BaseModel):
 class KnowledgeBaseDetailResponse(BaseModel):
     id: str = Field(..., description="知识库ID")
     name: str = Field(..., description="知识库名称")
-    description: str = Field(..., description="知识库描述")
+    description: Optional[str] = Field(None, description="知识库描述")
     config: Optional[KnowledgeBaseConfig] = Field(..., description="知识库配置")
 
 
@@ -205,3 +206,58 @@ class KnowledgeBaseCreateDocumentsRequest(BaseModel):
     processOption: Optional[DocumentProcessOption] = Field(
         None, description="文档处理选项"
     )
+
+
+class CreateChunkRequest(BaseModel):
+    documentId: str = Field(..., description="文档ID")
+    content: str = Field(..., description="文档内容")
+
+
+class CreateChunkResponse(BaseModel):
+    id: str = Field(..., description="切片ID")
+
+
+class ModifyChunkRequest(BaseModel):
+    chunkId: str = Field(..., description="切片ID")
+    content: str = Field(..., description="文档内容")
+    enable: bool = Field(..., description="是否启用")
+
+
+class DeleteChunkRequest(BaseModel):
+    chunkId: str = Field(..., description="切片ID")
+
+
+class DescribeChunkRequest(BaseModel):
+    chunkId: str = Field(..., description="切片ID")
+
+
+class DescribeChunkResponse(BaseModel):
+    id: str = Field(..., description="切片ID")
+    type: int = Field(..., description="切片类型")
+    knowledgeBaseId: str = Field(..., description="知识库ID")
+    documentId: str = Field(..., description="文档ID")
+    content: str = Field(..., description="文档内容")
+    enabled: bool = Field(..., description="是否启用")
+    wordCount: int = Field(..., description="切片内字符数量")
+    tokenCount: int = Field(..., description="切片内token数量")
+    status: str = Field(..., description="切片状态")
+    statusMessage: str = Field(..., description="切片状态信息")
+    createdAt: int = Field(..., description="创建时间")
+    updatedAt: int = Field(..., description="更新时间")
+
+
+class DescribeChunksRequest(BaseModel):
+    documentId: str = Field(..., description="文档ID")
+    marker: str = Field(..., description="起始位置")
+    maxKeys: int = Field(..., description="返回文档数量大小，默认10，最大值100")
+    type: Optional[int] = Field(None, description="切片类型")
+
+
+class DescribeChunksResponse(BaseModel):
+    data: list[DescribeChunkResponse] = Field(..., description="切片列表")
+    marker: str = Field(..., description="起始位置")
+    isTruncated: bool = Field(
+        ..., description="true表示后面还有数据，false表示已经是最后一页"
+    )
+    nextMarker: str = Field(..., description="下一页起始位置")
+    maxKeys: int = Field(..., description="本次查询包含的最大结果集数量")

--- a/appbuilder/core/console/knowledge_base/data_class.py
+++ b/appbuilder/core/console/knowledge_base/data_class.py
@@ -243,7 +243,7 @@ class DescribeChunkResponse(BaseModel):
     status: str = Field(..., description="切片状态")
     statusMessage: str = Field(..., description="切片状态信息")
     createTime: int = Field(..., description="创建时间")
-    updateTime: int = Field(..., description="更新时间")
+    updateTime: int = Field(None, description="更新时间")
 
 
 class DescribeChunksRequest(BaseModel):

--- a/appbuilder/core/console/knowledge_base/data_class.py
+++ b/appbuilder/core/console/knowledge_base/data_class.py
@@ -76,8 +76,8 @@ class KnowledgeBaseGetDocumentsListRequest(BaseModel):
 
 
 class DocumentMeta(BaseModel):
-    source: str = Field("", description="文档来源")
-    file_id: str = Field("", description="文档对应的文件ID")
+    source: str = Field(None, description="文档来源")
+    file_id: str = Field(None, description="文档对应的文件ID")
 
 
 class Document(BaseModel):

--- a/appbuilder/core/console/knowledge_base/data_class.py
+++ b/appbuilder/core/console/knowledge_base/data_class.py
@@ -233,7 +233,7 @@ class DescribeChunkRequest(BaseModel):
 
 class DescribeChunkResponse(BaseModel):
     id: str = Field(..., description="切片ID")
-    type: int = Field(..., description="切片类型")
+    type: str = Field(..., description="切片类型")
     knowledgeBaseId: str = Field(..., description="知识库ID")
     documentId: str = Field(..., description="文档ID")
     content: str = Field(..., description="文档内容")
@@ -242,15 +242,15 @@ class DescribeChunkResponse(BaseModel):
     tokenCount: int = Field(..., description="切片内token数量")
     status: str = Field(..., description="切片状态")
     statusMessage: str = Field(..., description="切片状态信息")
-    createdAt: int = Field(..., description="创建时间")
-    updatedAt: int = Field(..., description="更新时间")
+    createTime: int = Field(..., description="创建时间")
+    updateTime: int = Field(..., description="更新时间")
 
 
 class DescribeChunksRequest(BaseModel):
     documentId: str = Field(..., description="文档ID")
     marker: str = Field(..., description="起始位置")
     maxKeys: int = Field(..., description="返回文档数量大小，默认10，最大值100")
-    type: Optional[int] = Field(None, description="切片类型")
+    type: Optional[str] = Field(None, description="切片类型")
 
 
 class DescribeChunksResponse(BaseModel):

--- a/appbuilder/core/console/knowledge_base/data_class.py
+++ b/appbuilder/core/console/knowledge_base/data_class.py
@@ -27,17 +27,21 @@ class KnowledgeBaseUploadFileResponse(BaseModel):
 class CustomProcessRule(BaseModel):
     separators: list[str] = Field(..., description="分段符号列表", example=[",", "?"])
     target_length: int = Field(..., description="分段最大长度", ge=300, le=1200)
-    overlap_rate: float = Field(..., description="分段重叠最大字数占比，推荐值0.25", ge=0, le=0.3, example=0.2)
+    overlap_rate: float = Field(
+        ..., description="分段重叠最大字数占比，推荐值0.25", ge=0, le=0.3, example=0.2
+    )
 
 
 class KnowledgeBaseAddDocumentRequest(BaseModel):
     knowledge_base_id: str = Field(..., description="知识库ID")
     content_type: str = Field(
-        'raw_text', description="文档类型", enum=["raw_text", "qa"])
+        "raw_text", description="文档类型", enum=["raw_text", "qa"]
+    )
     file_ids: list[str] = Field(..., description="文件ID列表")
     is_enhanced: bool = Field(False, description="是否开启知识增强")
     custom_process_rule: Optional[CustomProcessRule] = Field(
-        None, description="自定义分段规则")
+        None, description="自定义分段规则"
+    )
 
 
 class KnowledgeBaseAddDocumentResponse(BaseModel):
@@ -57,15 +61,23 @@ class KnowledgeBaseDeleteDocumentResponse(BaseModel):
 
 class KnowledgeBaseGetDocumentsListRequest(BaseModel):
     knowledge_base_id: str = Field(..., description="知识库ID")
-    limit: int = Field(10, description="返回文档数量大小，默认10，最大值100", le=100, ge=1)
+    limit: int = Field(
+        10, description="返回文档数量大小，默认10，最大值100", le=100, ge=1
+    )
     after: str = Field(
-        "", description="用于分页的游标。after 是一个文档的id，它定义了在列表中的位置。例如，如果你发出一个列表请求并收到 10个对象，以 app_id_123 结束，那么你后续的调用可以包含 after=app_id_123 以获取列表的下一页数据。")
+        "",
+        description="用于分页的游标。after 是一个文档的id，它定义了在列表中的位置。例如，如果你发出一个列表请求并收到 10个对象，以 app_id_123 结束，那么你后续的调用可以包含 after=app_id_123 以获取列表的下一页数据。",
+    )
     before: str = Field(
-        "", description="用于分页的游标。与after相反，填写它将获取前一页数据,如果和after都传，两个参数都会起到分页效果，维度是创建时间")
+        "",
+        description="用于分页的游标。与after相反，填写它将获取前一页数据,如果和after都传，两个参数都会起到分页效果，维度是创建时间",
+    )
+
 
 class DocumentMeta(BaseModel):
     source: str = Field("", description="文档来源")
     file_id: str = Field("", description="文档对应的文件ID")
+
 
 class Document(BaseModel):
     id: str = Field(..., description="文档ID")
@@ -73,9 +85,123 @@ class Document(BaseModel):
     created_at: int = Field(..., description="文档创建时间")
     word_count: int = Field(..., description="文档字数")
     enabled: bool = Field(True, description="文档是否可用")
-    meta: Optional[DocumentMeta] = Field(..., description="文档元信息，包括source、file_id")
+    meta: Optional[DocumentMeta] = Field(
+        ..., description="文档元信息，包括source、file_id"
+    )
 
 
 class KnowledgeBaseGetDocumentsListResponse(BaseModel):
     request_id: str = Field(..., description="请求ID")
     data: list[Document] = Field([], description="文档信息列表")
+
+
+class KnowledgeBaseConfigIndex(BaseModel):
+    type: str = Field(..., description="索引类型", enum=["public", "bes", "vdb"])
+    esUrl: Optional[str] = Field(..., description="ES地址")
+    username: Optional[str] = Field(None, description="ES用户名")
+    password: Optional[str] = Field(None, description="ES密码")
+
+
+class KnowledgeBaseConfig(BaseModel):
+    index: Optional[KnowledgeBaseConfigIndex] = Field(..., description="索引配置")
+
+
+class KnowledgeBaseCreateKnowledgeBaseRequest(BaseModel):
+    name: str = Field(..., description="知识库名称")
+    description: str = Field(None, description="知识库描述")
+    config: Optional[KnowledgeBaseConfig] = Field(..., description="知识库配置")
+
+
+class KnowledgeBaseGetDetailRequest(BaseModel):
+    id: str = Field(..., description="知识库ID")
+
+
+class KnowledgeBaseDetailResponse(BaseModel):
+    id: str = Field(..., description="知识库ID")
+    name: str = Field(..., description="知识库名称")
+    description: str = Field(..., description="知识库描述")
+    config: Optional[KnowledgeBaseConfig] = Field(..., description="知识库配置")
+
+
+class KnowledgeBaseModifyRequest(BaseModel):
+    id: str = Field(..., description="知识库ID")
+    name: Optional[str] = Field(None, description="知识库名称")
+    description: Optional[str] = Field(None, description="知识库描述")
+
+
+class KnowledgeBaseDeleteRequest(BaseModel):
+    id: str = Field(..., description="知识库ID")
+
+
+class KnowledgeBaseGetListRequest(BaseModel):
+    marker: str = Field(None, description="起始位置")
+    keyword: Optional[str] = Field(None, description="搜索关键字")
+    maxKeys: int = Field(
+        10, description="返回文档数量大小，默认10，最大值100", le=100, ge=1
+    )
+
+
+class KnowledgeBaseGetListResponse(BaseModel):
+    requestId: str = Field(..., description="请求ID")
+    data: list[KnowledgeBaseDetailResponse] = Field([], description="知识库详情列表")
+    marker: str = Field(..., description="起始位置")
+    nextMarker: str = Field(..., description="下一页起始位置")
+    maxKeys: int = Field(10, description="返回文档数量大小，默认10，最大值100")
+    isTruncated: bool = Field(..., description="是否有更多结果")
+
+
+class DocumentSource(BaseModel):
+    type: str = Field(..., description="数据来源类型", enum=["bos", "web"])
+    urls: list[str] = Field(None, description="文档URL")
+    urlDepth: int = Field(None, description="url下钻深度，1时不下钻")
+
+
+class DocumentChoices(BaseModel):
+    choices: list[str] = Field(..., description="选择项")
+
+
+class DocumentSeparator(BaseModel):
+    separators: list[str] = Field(..., description="分段符号")
+    targetLength: int = Field(..., description="分段最大长度")
+    overlapRate: float = Field(..., description="分段重叠最大字数占比，推荐值0.25")
+
+
+class DocumentPattern(BaseModel):
+    markPosition: str = Field(
+        ..., description="命中内容放置策略", enum=["head", "tail", "drop"]
+    )
+    regex: str = Field(..., description="正则表达式")
+    targetLength: int = Field(..., description="分段最大长度")
+    overlapRate: float = Field(..., description="分段重叠最大字数占比，推荐值0.25")
+
+
+class DocumentChunker(BaseModel):
+    choices: list[str] = Field(..., description="选择项")
+    prependInfo: list[str] = Field(
+        ...,
+        description="chunker关联元数据，可选值为title (增加标题), filename(增加文件名)",
+    )
+    separator: Optional[DocumentSeparator] = Field(..., description="分段符号")
+    pattern: Optional[DocumentPattern] = Field(None, description="正则表达式")
+
+
+class DocumentProcessOption(BaseModel):
+    template: str = Field(
+        ...,
+        description="模板类型",
+        enum=["ppt", "paper", "qaPair", "resume", " custom", "default"],
+    )
+    parser: Optional[DocumentChoices] = Field(None, description="解析器类型")
+    knowledgeAugmentation: Optional[DocumentChoices] = Field(
+        None, description="知识增强类型"
+    )
+    chunker: Optional[DocumentChunker] = Field(None, description="分段器类型")
+
+
+class KnowledgeBaseCreateDocumentsRequest(BaseModel):
+    id: str = Field(..., description="知识库ID")
+    source: DocumentSource = Field(..., description="文档来源")
+    contentFormat: str = Field(..., description="文档内容格式")
+    processOption: Optional[DocumentProcessOption] = Field(
+        None, description="文档处理选项"
+    )

--- a/appbuilder/core/console/knowledge_base/data_class.py
+++ b/appbuilder/core/console/knowledge_base/data_class.py
@@ -248,8 +248,10 @@ class DescribeChunkResponse(BaseModel):
 
 class DescribeChunksRequest(BaseModel):
     documentId: str = Field(..., description="文档ID")
-    marker: str = Field(..., description="起始位置")
-    maxKeys: int = Field(..., description="返回文档数量大小，默认10，最大值100")
+    marker: Optional[str] = Field(None, description="起始位置")
+    maxKeys: Optional[int] = Field(
+        None, description="返回文档数量大小，默认10，最大值100"
+    )
     type: Optional[str] = Field(None, description="切片类型")
 
 

--- a/appbuilder/core/console/knowledge_base/knowledge_base.py
+++ b/appbuilder/core/console/knowledge_base/knowledge_base.py
@@ -515,8 +515,8 @@ class KnowledgeBase(Component):
     def describe_chunks(
         self,
         documentId: str,
-        marker: str,
-        maxKeys: int,
+        marker: str = None,
+        maxKeys: int = None,
         type: str = None,
     ) -> data_class.DescribeChunkResponse:
         headers = self.http_client.auth_header_v2()

--- a/appbuilder/core/console/knowledge_base/knowledge_base.py
+++ b/appbuilder/core/console/knowledge_base/knowledge_base.py
@@ -517,7 +517,7 @@ class KnowledgeBase(Component):
         documentId: str,
         marker: str,
         maxKeys: int,
-        type: int = None,
+        type: str = None,
     ) -> data_class.DescribeChunkResponse:
         headers = self.http_client.auth_header_v2()
         headers["content-type"] = "application/json"

--- a/appbuilder/core/console/knowledge_base/knowledge_base.py
+++ b/appbuilder/core/console/knowledge_base/knowledge_base.py
@@ -211,6 +211,8 @@ class KnowledgeBase(Component):
         data = response.json()
 
         resp = data_class.KnowledgeBaseDetailResponse(**data)
+        self.knowledge_id = resp.id
+        self.knowledge_name = resp.name
         return resp
 
     def get_knowledge_base_detail(
@@ -409,3 +411,133 @@ class KnowledgeBase(Component):
             data = response.json()
 
         return data
+
+    def create_chunk(
+        self,
+        documentId: str,
+        content: str,
+    ) -> data_class.CreateChunkResponse:
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2("/knowledgeBase?Action=CreateChunk")
+
+        request = data_class.CreateChunkRequest(
+            documentId=documentId,
+            content=content,
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump(exclude_none=True)
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        resp = data_class.CreateChunkResponse(**data)
+        return resp
+
+    def modify_chunk(
+        self,
+        chunkId: str,
+        content: str,
+        enable: bool,
+    ):
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2("/knowledgeBase?Action=ModifyChunk")
+
+        request = data_class.ModifyChunkRequest(
+            chunkId=chunkId,
+            content=content,
+            enable=enable,
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump(exclude_none=True)
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        return data
+
+    def delete_chunk(
+        self,
+        chunkId: str,
+    ):
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2("/knowledgeBase?Action=DeleteChunk")
+
+        request = data_class.DeleteChunkRequest(
+            chunkId=chunkId,
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump(exclude_none=True)
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        return data
+
+    def describe_chunk(
+        self,
+        chunkId: str,
+    ) -> data_class.DescribeChunkResponse:
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2("/knowledgeBase?Action=DescribeChunk")
+
+        request = data_class.DescribeChunkRequest(
+            chunkId=chunkId,
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump(exclude_none=True)
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        resp = data_class.DescribeChunkResponse(**data)
+        return resp
+
+    def describe_chunks(
+        self,
+        documentId: str,
+        marker: str,
+        maxKeys: int,
+        type: int = None,
+    ) -> data_class.DescribeChunkResponse:
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2("/knowledgeBase?Action=DescribeChunks")
+
+        request = data_class.DescribeChunksRequest(
+            documentId=documentId,
+            marker=marker,
+            maxKeys=maxKeys,
+            type=type,
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump(exclude_none=True)
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        resp = data_class.DescribeChunksResponse(**data)
+        return resp

--- a/appbuilder/core/console/knowledge_base/knowledge_base.py
+++ b/appbuilder/core/console/knowledge_base/knowledge_base.py
@@ -518,7 +518,7 @@ class KnowledgeBase(Component):
         marker: str = None,
         maxKeys: int = None,
         type: str = None,
-    ) -> data_class.DescribeChunkResponse:
+    ) -> data_class.DescribeChunksResponse:
         headers = self.http_client.auth_header_v2()
         headers["content-type"] = "application/json"
 

--- a/appbuilder/core/console/knowledge_base/knowledge_base.py
+++ b/appbuilder/core/console/knowledge_base/knowledge_base.py
@@ -21,6 +21,7 @@ from typing import Optional
 from appbuilder.core._client import HTTPClient
 from appbuilder.core.console.knowledge_base import data_class
 from appbuilder.core.component import Message, Component
+from appbuilder.utils.func_utils import deprecated
 from appbuilder.utils.trace.tracer_wrapper import client_tool_trace
 
 
@@ -37,7 +38,11 @@ class KnowledgeBase(Component):
         self.knowledge_name = knowledge_name
 
     @classmethod
+    @deprecated
     def create_knowledge(cls, knowledge_name: str) -> "KnowledgeBase":
+        """
+        Deprecated: use create_knowledge_base instead
+        """
         payload = json.dumps({"name": knowledge_name})
         http_client = HTTPClient()
         headers = http_client.auth_header()

--- a/appbuilder/core/console/knowledge_base/knowledge_base.py
+++ b/appbuilder/core/console/knowledge_base/knowledge_base.py
@@ -26,24 +26,32 @@ from appbuilder.utils.trace.tracer_wrapper import client_tool_trace
 
 class KnowledgeBase(Component):
 
-    def __init__(self, knowledge_id: Optional[str] = None, knowledge_name: Optional[str] = None, **kwargs):
+    def __init__(
+        self,
+        knowledge_id: Optional[str] = None,
+        knowledge_name: Optional[str] = None,
+        **kwargs
+    ):
         super().__init__(**kwargs)
         self.knowledge_id = knowledge_id
         self.knowledge_name = knowledge_name
 
     @classmethod
-    def create_knowledge(cls, knowledge_name: str) -> 'KnowledgeBase':
+    def create_knowledge(cls, knowledge_name: str) -> "KnowledgeBase":
         payload = json.dumps({"name": knowledge_name})
         http_client = HTTPClient()
         headers = http_client.auth_header()
         headers["Content-Type"] = "application/json"
         create_url = "/v1/ai_engine/agi_platform/v1/datasets/create"
-        response = http_client.session.post(url=http_client.service_url(create_url),
-                                            headers=headers, data=payload)
+        response = http_client.session.post(
+            url=http_client.service_url(create_url), headers=headers, data=payload
+        )
         http_client.check_response_header(response)
         http_client.check_console_response(response)
         response = response.json()["result"]
-        return KnowledgeBase(knowledge_id=response["id"], knowledge_name=response["name"])
+        return KnowledgeBase(
+            knowledge_id=response["id"], knowledge_name=response["name"]
+        )
 
     def upload_file(self, file_path: str) -> data_class.KnowledgeBaseUploadFileResponse:
         if not os.path.exists(file_path):
@@ -52,10 +60,8 @@ class KnowledgeBase(Component):
         headers = self.http_client.auth_header_v2()
         url = self.http_client.service_url_v2("/file")
 
-        with open(file_path, 'rb') as f:
-            multipart_form_data = {
-                'file': (os.path.basename(file_path), f)
-            }
+        with open(file_path, "rb") as f:
+            multipart_form_data = {"file": (os.path.basename(file_path), f)}
 
             response = self.http_client.session.post(
                 url=url,
@@ -70,18 +76,21 @@ class KnowledgeBase(Component):
 
         return resp
 
-    def add_document(self,
-                     content_type: str,
-                     file_ids: list[str] = [],
-                     is_enhanced: bool = False,
-                     custom_process_rule: Optional[data_class.CustomProcessRule] = None,
-                     knowledge_base_id: Optional[str] = None) -> data_class.KnowledgeBaseAddDocumentResponse:
+    def add_document(
+        self,
+        content_type: str,
+        file_ids: list[str] = [],
+        is_enhanced: bool = False,
+        custom_process_rule: Optional[data_class.CustomProcessRule] = None,
+        knowledge_base_id: Optional[str] = None,
+    ) -> data_class.KnowledgeBaseAddDocumentResponse:
         if self.knowledge_id == None and knowledge_base_id == None:
             raise ValueError(
-                "knowledge_base_id cannot be empty, please call `create` first or use existing one")
+                "knowledge_base_id cannot be empty, please call `create` first or use existing one"
+            )
 
         headers = self.http_client.auth_header_v2()
-        headers['content-type'] = 'application/json'
+        headers["content-type"] = "application/json"
 
         url = self.http_client.service_url_v2("/knowledge_base/document")
 
@@ -90,72 +99,313 @@ class KnowledgeBase(Component):
             content_type=content_type,
             file_ids=file_ids,
             is_enhanced=is_enhanced,
-            custom_process_rule=custom_process_rule
+            custom_process_rule=custom_process_rule,
         )
 
         response = self.http_client.session.post(
-            url=url,
-            headers=headers,
-            json=request.model_dump()
+            url=url, headers=headers, json=request.model_dump()
         )
 
         self.http_client.check_response_header(response)
         self.http_client.check_console_response(response)
         data = response.json()
-        
+
         resp = data_class.KnowledgeBaseAddDocumentResponse(**data)
         return resp
 
-    def delete_document(self, document_id: str, knowledge_base_id: Optional[str] = None) -> data_class.KnowledgeBaseDeleteDocumentResponse:
+    def delete_document(
+        self, document_id: str, knowledge_base_id: Optional[str] = None
+    ) -> data_class.KnowledgeBaseDeleteDocumentResponse:
         if self.knowledge_id == None and knowledge_base_id == None:
             raise ValueError(
-                "knowledge_base_id cannot be empty, please call `create` first or use existing one")
+                "knowledge_base_id cannot be empty, please call `create` first or use existing one"
+            )
 
         headers = self.http_client.auth_header_v2()
-        headers['content-type'] = 'application/json'
+        headers["content-type"] = "application/json"
 
         url = self.http_client.service_url_v2("/knowledge_base/document")
         request = data_class.KnowledgeBaseDeleteDocumentRequest(
             knowledge_base_id=knowledge_base_id or self.knowledge_id,
-            document_id=document_id
+            document_id=document_id,
         )
         response = self.http_client.session.delete(
-            url=url,
-            headers=headers,
-            params=request.model_dump()
+            url=url, headers=headers, params=request.model_dump()
         )
 
         self.http_client.check_response_header(response)
         self.http_client.check_console_response(response)
         data = response.json()
-        
+
         resp = data_class.KnowledgeBaseDeleteDocumentResponse(**data)
         return resp
 
-    def get_documents_list(self, limit: int = 10, after: Optional[str] = "", before: Optional[str] = "", knowledge_base_id: Optional[str] = None)->data_class.KnowledgeBaseGetDocumentsListResponse:
+    def get_documents_list(
+        self,
+        limit: int = 10,
+        after: Optional[str] = "",
+        before: Optional[str] = "",
+        knowledge_base_id: Optional[str] = None,
+    ) -> data_class.KnowledgeBaseGetDocumentsListResponse:
         if self.knowledge_id == None and knowledge_base_id == None:
             raise ValueError(
-                "knowledge_base_id cannot be empty, please call `create` first or use existing one")
+                "knowledge_base_id cannot be empty, please call `create` first or use existing one"
+            )
 
         headers = self.http_client.auth_header_v2()
-        headers['content-type'] = 'application/json'
+        headers["content-type"] = "application/json"
 
         url = self.http_client.service_url_v2("/knowledge_base/documents")
         request = data_class.KnowledgeBaseGetDocumentsListRequest(
             knowledge_base_id=knowledge_base_id or self.knowledge_id,
             limit=limit,
             after=after,
-            before=before
+            before=before,
         )
         response = self.http_client.session.get(
-            url=url,
-            headers=headers,
-            params=request.model_dump()
+            url=url, headers=headers, params=request.model_dump()
         )
 
         self.http_client.check_response_header(response)
         self.http_client.check_console_response(response)
         data = response.json()
-        
+
         resp = data_class.KnowledgeBaseGetDocumentsListResponse(**data)
         return resp
+
+    def create_knowledge_base(
+        self,
+        name: str,
+        description: str,
+        type: str = "public",
+        esUrl: str = None,
+        esUserName: str = None,
+        esPassword: str = None,
+    ) -> data_class.KnowledgeBaseDetailResponse:
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2(
+            "/knowledgeBase?Action=CreateKnowledgeBase"
+        )
+
+        request = data_class.KnowledgeBaseCreateKnowledgeBaseRequest(
+            name=name,
+            description=description,
+            config={
+                "index": {
+                    "type": type,
+                    "esUrl": esUrl,
+                    "username": esUserName,
+                    "password": esPassword,
+                }
+            },
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump(exclude_none=True)
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        resp = data_class.KnowledgeBaseDetailResponse(**data)
+        return resp
+
+    def get_knowledge_base_detail(
+        self, knowledge_base_id: Optional[str] = None
+    ) -> data_class.KnowledgeBaseDetailResponse:
+        if self.knowledge_id == None and knowledge_base_id == None:
+            raise ValueError(
+                "knowledge_base_id cannot be empty, please call `create` first or use existing one"
+            )
+
+        request = data_class.KnowledgeBaseGetDetailRequest(
+            id=knowledge_base_id or self.knowledge_id
+        )
+
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2(
+            "/knowledgeBase?Action=DescribeKnowledgeBase"
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump()
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        resp = data_class.KnowledgeBaseDetailResponse(**data)
+        return resp
+
+    def modify_knowledge_base(
+        self,
+        knowledge_base_id: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        if self.knowledge_id == None and knowledge_base_id == None:
+            raise ValueError(
+                "knowledge_base_id cannot be empty, please call `create` first or use existing one"
+            )
+        request = data_class.KnowledgeBaseModifyRequest(
+            id=knowledge_base_id or self.knowledge_id,
+            name=name,
+            description=description,
+        )
+
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2(
+            "/knowledgeBase?Action=ModifyKnowledgeBase"
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump(exclude_none=True)
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        return data
+
+    def delete_knowledge_base(self, knowledge_base_id: Optional[str] = None):
+        if self.knowledge_id == None and knowledge_base_id == None:
+            raise ValueError(
+                "knowledge_base_id cannot be empty, please call `create` first or use existing one"
+            )
+        request = data_class.KnowledgeBaseDeleteRequest(
+            id=knowledge_base_id or self.knowledge_id
+        )
+
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2(
+            "/knowledgeBase?Action=DeleteKnowledgeBase"
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump()
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        return data
+
+    def create_documents(
+        self,
+        id: Optional[str] = None,
+        contentFormat: str = "",
+        source: data_class.DocumentSource = None,
+        processOption: data_class.DocumentProcessOption = None,
+    ):
+        if self.knowledge_id == None and id == None:
+            raise ValueError(
+                "knowledge_base_id cannot be empty, please call `create` first or use existing one"
+            )
+
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2("/knowledgeBase?Action=CreateDocuments")
+
+        request = data_class.KnowledgeBaseCreateDocumentsRequest(
+            id=id or self.knowledge_id,
+            source=source,
+            contentFormat=contentFormat,
+            processOption=processOption,
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump(exclude_none=True)
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        return data
+
+    def get_knowledge_base_list(
+        self,
+        knowledge_base_id: Optional[str] = None,
+        maxKeys: int = 10,
+        keyword: Optional[str] = None,
+    ) -> data_class.KnowledgeBaseGetListResponse:
+        if self.knowledge_id == None and knowledge_base_id == None:
+            raise ValueError(
+                "knowledge_base_id cannot be empty, please call `create` first or use existing one"
+            )
+        request = data_class.KnowledgeBaseGetListRequest(
+            marker=knowledge_base_id or self.knowledge_id,
+            maxKeys=maxKeys,
+            keyword=keyword,
+        )
+
+        headers = self.http_client.auth_header_v2()
+        headers["content-type"] = "application/json"
+
+        url = self.http_client.service_url_v2(
+            "/knowledgeBase?Action=DescribeKnowledgeBases"
+        )
+
+        response = self.http_client.session.post(
+            url=url, headers=headers, json=request.model_dump(exclude_none=True)
+        )
+
+        self.http_client.check_response_header(response)
+        self.http_client.check_console_response(response)
+        data = response.json()
+
+        resp = data_class.KnowledgeBaseGetListResponse(**data)
+        return resp
+
+    def upload_documents(
+        self,
+        file_path: str,
+        content_format: str = "rawText",
+        id: Optional[str] = None,
+        processOption: data_class.DocumentProcessOption = None,
+    ):
+        if not os.path.exists(file_path):
+            raise FileNotFoundError("File {} does not exist".format(file_path))
+
+        headers = self.http_client.auth_header_v2()
+        url = self.http_client.service_url_v2("/knowledgeBase?Action=UploadDocuments")
+
+        with open(file_path, "rb") as f:
+            multipart_form_data = {"file": (os.path.basename(file_path), f)}
+
+            request = data_class.KnowledgeBaseCreateDocumentsRequest(
+                id=id or self.knowledge_id,
+                source=data_class.DocumentSource(type="file"),
+                contentFormat=content_format,
+                processOption=processOption,
+            )
+
+            data = {
+                "payload": request.model_dump_json(exclude_none=True),
+            }
+
+            response = self.http_client.session.post(
+                url=url,
+                headers=headers,
+                data=data,
+                files=multipart_form_data,
+            )
+
+            self.http_client.check_response_header(response)
+            self.http_client.check_console_response(response)
+            data = response.json()
+
+        return data

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -104,15 +104,6 @@ class TestKnowLedge(unittest.TestCase):
             ),
         )
 
-        knowledge.modify_knowledge_base(
-            knowledge_base_id=knowledge_base_id, name="test"
-        )
-        knowledge.delete_knowledge_base(knowledge_base_id)
-        self.assertIsNotNone(knowledge_base_id)
-
-    def test_create_chunk(self):
-        dataset_id = os.getenv("DATASET_ID", "UNKNOWN")
-        knowledge = appbuilder.KnowledgeBase(knowledge_id=dataset_id)
         list_res = knowledge.get_documents_list()
         document_id = list_res.data[0].id
         resp = knowledge.create_chunk(document_id, content="test")
@@ -121,6 +112,12 @@ class TestKnowLedge(unittest.TestCase):
         knowledge.describe_chunks(document_id)
         knowledge.describe_chunk(chunk_id)
         knowledge.delete_chunk(chunk_id)
+
+        knowledge.modify_knowledge_base(
+            knowledge_base_id=knowledge_base_id, name="test"
+        )
+        knowledge.delete_knowledge_base(knowledge_base_id)
+        self.assertIsNotNone(knowledge_base_id)
 
 
 if __name__ == "__main__":

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -104,19 +104,25 @@ class TestKnowLedge(unittest.TestCase):
             ),
         )
 
-        list_res = knowledge.get_documents_list()
-        document_id = list_res.data[-1].id
-        res = knowledge.describe_chunks(document_id)
-        knowledge.describe_chunk(res.data[0].id)
-        resp = knowledge.create_chunk(document_id, content="test")
-        chunk_id = resp.id
-        knowledge.modify_chunk(chunk_id, content="new test", enable=True)
-        knowledge.delete_chunk(chunk_id)
+        try:
+            list_res = knowledge.get_documents_list()
+            document_id = list_res.data[-1].id
+            res = knowledge.describe_chunks(document_id)
+            knowledge.describe_chunk(res.data[0].id)
+            resp = knowledge.create_chunk(document_id, content="test")
+            chunk_id = resp.id
+            knowledge.modify_chunk(chunk_id, content="new test", enable=True)
+            knowledge.delete_chunk(chunk_id)
 
-        knowledge.modify_knowledge_base(
-            knowledge_base_id=knowledge_base_id, name="test"
-        )
-        knowledge.delete_knowledge_base(knowledge_base_id)
+            knowledge.modify_knowledge_base(
+                knowledge_base_id=knowledge_base_id, name="test"
+            )
+            knowledge.delete_knowledge_base(knowledge_base_id)
+        except Exception as e:
+            print("错误为 {}".format(e))
+        finally:
+            knowledge.delete_knowledge_base(knowledge_base_id)
+
         self.assertIsNotNone(knowledge_base_id)
 
 

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -110,6 +110,18 @@ class TestKnowLedge(unittest.TestCase):
         knowledge.delete_knowledge_base(knowledge_base_id)
         self.assertIsNotNone(knowledge_base_id)
 
+    def test_create_chunk(self):
+        dataset_id = os.getenv("DATASET_ID", "UNKNOWN")
+        knowledge = appbuilder.KnowledgeBase(knowledge_id=dataset_id)
+        list_res = knowledge.get_documents_list()
+        document_id = list_res.data[0].id
+        resp = self.knowledge.create_chunk(document_id, content="test")
+        chunk_id = resp.id
+        knowledge.modify_chunk(chunk_id, content="new test", enable=True)
+        knowledge.describe_chunk(chunk_id)
+        knowledge.describe_chunks(document_id)
+        knowledge.delete_chunk(chunk_id)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -60,58 +60,64 @@ class TestKnowLedge(unittest.TestCase):
         knowledge_base_id = resp.id
         knowledge.get_knowledge_base_detail(knowledge_base_id)
         knowledge.get_knowledge_base_list(knowledge_base_id, maxKeys=10)
-        knowledge.create_documents(
-            id=knowledge_base_id,
-            contentFormat="rawText",
-            source=appbuilder.DocumentSource(
-                type="web",
-                urls=["https://baijiahao.baidu.com/s?id=1802527379394162441"],
-                urlDepth=1,
-            ),
-            processOption=appbuilder.DocumentProcessOption(
-                template="custom",
-                parser=appbuilder.DocumentChoices(choices=["layoutAnalysis", "ocr"]),
-                chunker=appbuilder.DocumentChunker(
-                    choices=["separator"],
-                    separator=appbuilder.DocumentSeparator(
-                        separators=["。"],
-                        targetLength=300,
-                        overlapRate=0.25,
-                    ),
-                    prependInfo=["title", "filename"],
-                ),
-                knowledgeAugmentation=appbuilder.DocumentChoices(choices=["faq"]),
-            ),
-        )
-
-        knowledge.upload_documents(
-            id=knowledge_base_id,
-            content_format="rawText",
-            file_path="./data/qa_appbuilder_client_demo.pdf",
-            processOption=appbuilder.DocumentProcessOption(
-                template="custom",
-                parser=appbuilder.DocumentChoices(choices=["layoutAnalysis", "ocr"]),
-                chunker=appbuilder.DocumentChunker(
-                    choices=["separator"],
-                    separator=appbuilder.DocumentSeparator(
-                        separators=["。"],
-                        targetLength=300,
-                        overlapRate=0.25,
-                    ),
-                    prependInfo=["title", "filename"],
-                ),
-                knowledgeAugmentation=appbuilder.DocumentChoices(choices=["faq"]),
-            ),
-        )
 
         try:
+            knowledge.create_documents(
+                id=knowledge_base_id,
+                contentFormat="rawText",
+                source=appbuilder.DocumentSource(
+                    type="web",
+                    urls=["https://baijiahao.baidu.com/s?id=1802527379394162441"],
+                    urlDepth=1,
+                ),
+                processOption=appbuilder.DocumentProcessOption(
+                    template="custom",
+                    parser=appbuilder.DocumentChoices(
+                        choices=["layoutAnalysis", "ocr"]
+                    ),
+                    chunker=appbuilder.DocumentChunker(
+                        choices=["separator"],
+                        separator=appbuilder.DocumentSeparator(
+                            separators=["。"],
+                            targetLength=300,
+                            overlapRate=0.25,
+                        ),
+                        prependInfo=["title", "filename"],
+                    ),
+                    knowledgeAugmentation=appbuilder.DocumentChoices(choices=["faq"]),
+                ),
+            )
+
+            knowledge.upload_documents(
+                id=knowledge_base_id,
+                content_format="rawText",
+                file_path="./data/qa_appbuilder_client_demo.pdf",
+                processOption=appbuilder.DocumentProcessOption(
+                    template="custom",
+                    parser=appbuilder.DocumentChoices(
+                        choices=["layoutAnalysis", "ocr"]
+                    ),
+                    chunker=appbuilder.DocumentChunker(
+                        choices=["separator"],
+                        separator=appbuilder.DocumentSeparator(
+                            separators=["。"],
+                            targetLength=300,
+                            overlapRate=0.25,
+                        ),
+                        prependInfo=["title", "filename"],
+                    ),
+                    knowledgeAugmentation=appbuilder.DocumentChoices(choices=["faq"]),
+                ),
+            )
+
             list_res = knowledge.get_documents_list()
             document_id = list_res.data[-1].id
             res = knowledge.describe_chunks(document_id)
-            knowledge.describe_chunk(res.data[0].id)
             resp = knowledge.create_chunk(document_id, content="test")
             chunk_id = resp.id
             knowledge.modify_chunk(chunk_id, content="new test", enable=True)
+            time.sleep(1)
+            knowledge.describe_chunk(chunk_id)
             knowledge.delete_chunk(chunk_id)
 
             knowledge.modify_knowledge_base(

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -115,7 +115,7 @@ class TestKnowLedge(unittest.TestCase):
         knowledge = appbuilder.KnowledgeBase(knowledge_id=dataset_id)
         list_res = knowledge.get_documents_list()
         document_id = list_res.data[0].id
-        resp = self.knowledge.create_chunk(document_id, content="test")
+        resp = knowledge.create_chunk(document_id, content="test")
         chunk_id = resp.id
         knowledge.modify_chunk(chunk_id, content="new test", enable=True)
         knowledge.describe_chunk(chunk_id)

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -105,12 +105,12 @@ class TestKnowLedge(unittest.TestCase):
         )
 
         list_res = knowledge.get_documents_list()
-        document_id = list_res.data[0].id
+        document_id = list_res.data[-1].id
+        res = knowledge.describe_chunks(document_id)
+        knowledge.describe_chunk(res.data[0].id)
         resp = knowledge.create_chunk(document_id, content="test")
         chunk_id = resp.id
         knowledge.modify_chunk(chunk_id, content="new test", enable=True)
-        knowledge.describe_chunks(document_id)
-        knowledge.describe_chunk(chunk_id)
         knowledge.delete_chunk(chunk_id)
 
         knowledge.modify_knowledge_base(

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -124,7 +124,6 @@ class TestKnowLedge(unittest.TestCase):
             knowledge.modify_knowledge_base(
                 knowledge_base_id=knowledge_base_id, name="test"
             )
-            knowledge.delete_knowledge_base(knowledge_base_id)
         except Exception as e:
             err_msg = str(e)
             print("错误为 {}".format(e))

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -118,8 +118,8 @@ class TestKnowLedge(unittest.TestCase):
         resp = knowledge.create_chunk(document_id, content="test")
         chunk_id = resp.id
         knowledge.modify_chunk(chunk_id, content="new test", enable=True)
-        knowledge.describe_chunk(chunk_id)
         knowledge.describe_chunks(document_id)
+        knowledge.describe_chunk(chunk_id)
         knowledge.delete_chunk(chunk_id)
 
 

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -61,6 +61,7 @@ class TestKnowLedge(unittest.TestCase):
         knowledge.get_knowledge_base_detail(knowledge_base_id)
         knowledge.get_knowledge_base_list(knowledge_base_id, maxKeys=10)
 
+        err_msg = None
         try:
             knowledge.create_documents(
                 id=knowledge_base_id,
@@ -125,11 +126,12 @@ class TestKnowLedge(unittest.TestCase):
             )
             knowledge.delete_knowledge_base(knowledge_base_id)
         except Exception as e:
+            err_msg = str(e)
             print("错误为 {}".format(e))
         finally:
             knowledge.delete_knowledge_base(knowledge_base_id)
 
-        self.assertIsNotNone(knowledge_base_id)
+        self.assertIsNone(err_msg)
 
 
 if __name__ == "__main__":

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -117,9 +117,8 @@ class TestKnowLedge(unittest.TestCase):
             resp = knowledge.create_chunk(document_id, content="test")
             chunk_id = resp.id
             knowledge.modify_chunk(chunk_id, content="new test", enable=True)
-            # 目前openapi有延迟，后续openapi完善后，删除这段
-            time.sleep(5)
-            knowledge.describe_chunk(chunk_id)
+            # 目前openapi有延迟，后续openapi完善后，删除注释
+            # knowledge.describe_chunk(chunk_id)
             knowledge.delete_chunk(chunk_id)
 
             knowledge.modify_knowledge_base(

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -19,30 +19,97 @@ import os
 import time
 import logging
 
-@unittest.skipUnless(os.getenv("TEST_CASE", "UNKNOWN") == "CPU_SERIAL","")
+
+@unittest.skipUnless(os.getenv("TEST_CASE", "UNKNOWN") == "CPU_SERIAL", "")
 class TestKnowLedge(unittest.TestCase):
     def test_doc_knowledage(self):
         dataset_id = os.getenv("DATASET_ID", "UNKNOWN")
         knowledge = appbuilder.KnowledgeBase(knowledge_id=dataset_id)
 
         upload_res = knowledge.upload_file("./data/qa_appbuilder_client_demo.pdf")
-        add_res = knowledge.add_document(content_type='raw_text',
-                                         file_ids=[upload_res.id],
-                                         custom_process_rule=appbuilder.CustomProcessRule(
-                                            separators=["?"], target_length=400,overlap_rate=0.2
-                                         ))
+        add_res = knowledge.add_document(
+            content_type="raw_text",
+            file_ids=[upload_res.id],
+            custom_process_rule=appbuilder.CustomProcessRule(
+                separators=["?"], target_length=400, overlap_rate=0.2
+            ),
+        )
         list_res = knowledge.get_documents_list()
         delete_res = knowledge.delete_document(document_id=add_res.document_ids[0])
-    
+
     def test_xlsx_knowledage(self):
         dataset_id = os.getenv("DATASET_ID", "UNKNOWN")
         knowledge = appbuilder.KnowledgeBase(knowledge_id=dataset_id)
 
         upload_res = knowledge.upload_file("./data/qa_demo.xlsx")
-        add_res = knowledge.add_document(content_type='qa', file_ids=[upload_res.id])
+        add_res = knowledge.add_document(content_type="qa", file_ids=[upload_res.id])
         list_res = knowledge.get_documents_list()
         delete_res = knowledge.delete_document(document_id=add_res.document_ids[0])
 
+    def test_create_knowledge_base(self):
+        knowledge = appbuilder.KnowledgeBase()
+        resp = knowledge.create_knowledge_base(
+            name="test",
+            description="test",
+            type="public",
+            esUrl="http://localhost:9200",
+            esUserName="elastic",
+            esPassword="changeme",
+        )
 
-if __name__ == '__main__':
+        knowledge_base_id = resp.id
+        knowledge.get_knowledge_base_detail(knowledge_base_id)
+        knowledge.get_knowledge_base_list(knowledge_base_id, maxKeys=10)
+        knowledge.create_documents(
+            id=knowledge_base_id,
+            contentFormat="rawText",
+            source=appbuilder.DocumentSource(
+                type="web",
+                urls=["https://baijiahao.baidu.com/s?id=1802527379394162441"],
+                urlDepth=1,
+            ),
+            processOption=appbuilder.DocumentProcessOption(
+                template="custom",
+                parser=appbuilder.DocumentChoices(choices=["layoutAnalysis", "ocr"]),
+                chunker=appbuilder.DocumentChunker(
+                    choices=["separator"],
+                    separator=appbuilder.DocumentSeparator(
+                        separators=["。"],
+                        targetLength=300,
+                        overlapRate=0.25,
+                    ),
+                    prependInfo=["title", "filename"],
+                ),
+                knowledgeAugmentation=appbuilder.DocumentChoices(choices=["faq"]),
+            ),
+        )
+
+        knowledge.upload_documents(
+            id=knowledge_base_id,
+            content_format="rawText",
+            file_path="./appbuilder/tests/data/qa_appbuilder_client_demo.pdf",
+            processOption=appbuilder.DocumentProcessOption(
+                template="custom",
+                parser=appbuilder.DocumentChoices(choices=["layoutAnalysis", "ocr"]),
+                chunker=appbuilder.DocumentChunker(
+                    choices=["separator"],
+                    separator=appbuilder.DocumentSeparator(
+                        separators=["。"],
+                        targetLength=300,
+                        overlapRate=0.25,
+                    ),
+                    prependInfo=["title", "filename"],
+                ),
+                knowledgeAugmentation=appbuilder.DocumentChoices(choices=["faq"]),
+            ),
+        )
+
+        knowledge.modify_knowledge_base(
+            knowledge_base_id=knowledge_base_id, name="test"
+        )
+        knowledge.delete_knowledge_base(knowledge_base_id)
+        self.assertIsNotNone(knowledge_base_id)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -87,7 +87,7 @@ class TestKnowLedge(unittest.TestCase):
         knowledge.upload_documents(
             id=knowledge_base_id,
             content_format="rawText",
-            file_path="./appbuilder/tests/data/qa_appbuilder_client_demo.pdf",
+            file_path="./data/qa_appbuilder_client_demo.pdf",
             processOption=appbuilder.DocumentProcessOption(
                 template="custom",
                 parser=appbuilder.DocumentChoices(choices=["layoutAnalysis", "ocr"]),

--- a/appbuilder/tests/test_knowledge_base.py
+++ b/appbuilder/tests/test_knowledge_base.py
@@ -117,7 +117,8 @@ class TestKnowLedge(unittest.TestCase):
             resp = knowledge.create_chunk(document_id, content="test")
             chunk_id = resp.id
             knowledge.modify_chunk(chunk_id, content="new test", enable=True)
-            time.sleep(1)
+            # 目前openapi有延迟，后续openapi完善后，删除这段
+            time.sleep(5)
             knowledge.describe_chunk(chunk_id)
             knowledge.delete_chunk(chunk_id)
 


### PR DESCRIPTION
python-sdk 新增知识库增删改查等OpenAPI:
接口范围：
1.知识库详情
2.知识库删除
3.知识库更新
4.创建知识库
5.上传文件到知识库
6.导入知识库（web-url部分
7.知识库列表

8.创建切片
9.修改切片
10.切片详情
11.切片列表
12.删除切片