### PR TITLE
更新PlayGround 组件的大模型对话可选参数

### DIFF
--- a/appbuilder/core/components/llms/base.py
+++ b/appbuilder/core/components/llms/base.py
@@ -388,7 +388,7 @@ class CompletionBaseComponent(Component):
 
         return query, inputs, response_mode, user_id
 
-    def get_model_config(self, model_config_inputs: ModelArgsConfig, other_params: dict):
+    def get_model_config(self, model_config_inputs: ModelArgsConfig, other_params: dict = {}):
         """获取模型配置信息"""
         self.model_config["model"]["name"] = self.model_name
 

--- a/appbuilder/core/components/llms/base.py
+++ b/appbuilder/core/components/llms/base.py
@@ -68,8 +68,12 @@ class CompletionRequest(object):
 
 class ModelArgsConfig(BaseModel):
     stream: bool = Field(default=False, description="是否流式响应。默认为 False。")
-    temperature: confloat(gt=0.0, le=1.0) = Field(default=1e-10, description="模型的温度参数，范围从 0.0 到 1.0。")
-    top_p: confloat(ge=0.0, le=1.0) = Field(default=1e-10, description="模型的top_p参数，范围从 0.0 到 1.0。")
+    temperature: float = Field(default=1e-10,gt=0.0, le=1.0 ,description="模型的温度参数，范围从 0.0 到 1.0。")
+    top_p: float= Field(default=1e-10, ge=0.0, le=1.0, description="模型的top_p参数，范围从 0.0 到 1.0。")
+    max_output_tokens: int = Field(default=1024, ge=2, description="最大输出token数。")
+    disable_search: bool = Field(default=True, description="是否禁用搜索。默认为 True")
+    response_format: str = Field(default="text", description="响应格式，可选项有text、json_object")
+    stop: list[str] = Field(default=[], description="停止词列表。", max_length=4)
 
 
 class CompletionResponse(object):
@@ -257,8 +261,6 @@ class CompletionBaseComponent(Component):
             "completion_params": {
                 "temperature": 1e-10,
                 "top_p": 0,
-                "presence_penalty": 0,
-                "frequency_penalty": 0
             }
         }
     }
@@ -392,6 +394,10 @@ class CompletionBaseComponent(Component):
 
         self.model_config["model"]["completion_params"]["temperature"] = model_config_inputs.temperature
         self.model_config["model"]["completion_params"]["top_p"] = model_config_inputs.top_p
+        self.model_config["model"]["completion_params"]["max_output_tokens"] = model_config_inputs.max_output_tokens
+        self.model_config["model"]["completion_params"]["disable_search"] = model_config_inputs.disable_search
+        self.model_config["model"]["completion_params"]["response_format"] = model_config_inputs.response_format
+        self.model_config["model"]["completion_params"]["stop"] = model_config_inputs.stop
         return self.model_config
 
     def completion(

--- a/appbuilder/core/components/llms/playground/README.md
+++ b/appbuilder/core/components/llms/playground/README.md
@@ -46,6 +46,11 @@ play(appbuilder.Message({"name": "小明", "bot_name": "小红", "bot_type": "�
 | message   | obj:`Message` | 输入消息，必需参数。              | 无    |
 | stream    | bool          | 是否以流式形式返回响应。           | False |
 | temperature | float        | 模型配置的温度参数。              | 1e-10 |
+| max_output_tokens | int        |  指定生成的文本的最大长度，默认最大输出token数为1024, 最小为2， 最大输出token与选择的模型有关           | 1024  |
+|disable_search| bool         | 是否关闭搜索功能，默认关闭          | True  |
+|response_format| str         | 指定返回的响应格式，可选值有：`text`, `json_object`| text  |
+|stop| str                   | 生成停止标识，当模型生成结果以stop中某个元素结尾时，停止文本生成。每个元素长度不超过20字符,最多4个元素.         | []  |
+
 
 ### 响应参数
 
@@ -74,3 +79,4 @@ play(appbuilder.Message({"name": "小明", "bot_name": "小红", "bot_type": "�
 
 ## 更新记录和贡献
 - 2024年01月24日 更新Readme格式，调整请求参数样式，新增特色优势
+- 2024年08月01日 更新playground组件的入参，并且前向兼容，支持未来的大模型对话参数

--- a/appbuilder/core/components/llms/playground/component.py
+++ b/appbuilder/core/components/llms/playground/component.py
@@ -84,7 +84,7 @@ class Playground(CompletionBaseComponent):
         self.variable_names = self.__parse__(prompt_template)
 
     @components_run_trace
-    def run(self, message, stream=False, temperature=1e-10, top_p=0.0, max_output_tokens=1024, disable_search=True, response_format='text', stop=[]):
+    def run(self, message, stream=False, temperature=1e-10, top_p=0.0, max_output_tokens=1024, disable_search=True, response_format='text', stop=[], **kwargs):
         """
         使用给定的输入运行模型并返回结果。
 
@@ -119,7 +119,7 @@ class Playground(CompletionBaseComponent):
         prompt = self.prompt_template.format(**inputs)
         query_message = Message(prompt)
         return super().run(message=query_message, stream=stream, temperature=temperature, top_p=top_p,
-                           max_output_tokens=max_output_tokens, disable_search=disable_search, response_format=response_format, stop=stop)
+                           max_output_tokens=max_output_tokens, disable_search=disable_search, response_format=response_format, stop=stop, **kwargs)
 
     def __parse__(self, prompt_template):
         last_end = 0

--- a/appbuilder/core/components/llms/playground/component.py
+++ b/appbuilder/core/components/llms/playground/component.py
@@ -54,10 +54,10 @@ class Playground(CompletionBaseComponent):
     variable_names = {}
 
     def __init__(
-        self, 
-        prompt_template=None, 
+        self,
+        prompt_template=None,
         model=None,
-        secret_key: Optional[str] = None, 
+        secret_key: Optional[str] = None,
         gateway: str = "",
         lazy_certification: bool = False,
     ):
@@ -75,7 +75,7 @@ class Playground(CompletionBaseComponent):
 
         """
         super().__init__(
-                PlaygroundArgs, model=model, secret_key=secret_key, gateway=gateway, lazy_certification=lazy_certification)
+            PlaygroundArgs, model=model, secret_key=secret_key, gateway=gateway, lazy_certification=lazy_certification)
 
         if prompt_template is None:
             prompt_template = "{query}"
@@ -84,7 +84,7 @@ class Playground(CompletionBaseComponent):
         self.variable_names = self.__parse__(prompt_template)
 
     @components_run_trace
-    def run(self, message, stream=False, temperature=1e-10, top_p=0.0):
+    def run(self, message, stream=False, temperature=1e-10, top_p=0.0, max_output_tokens=1024, disable_search=True, response_format='text', stop=[]):
         """
         使用给定的输入运行模型并返回结果。
 
@@ -93,6 +93,10 @@ class Playground(CompletionBaseComponent):
             stream (bool, 可选): 指定是否以流式形式返回响应。默认为 False。
             temperature (float, 可选): 模型配置的温度参数，用于调整模型的生成概率。取值范围为 0.0 到 1.0，其中较低的值使生成更确定性，较高的值使生成更多样性。默认值为 1e-10。
             top_p(float, optional): 影响输出文本的多样性，取值越大，生成文本的多样性越强。取值范围为 0.0 到 1.0，其中较低的值使生成更确定性，较高的值使生成更多样性。默认值为 0。
+            max_output_tokens (int, optional): 指定生成的文本的最大长度，默认最大输出token数为1024, 最小为2， 最大输出token与选择的模型有关
+            disable_search (bool, optional): 是否强制关闭实时搜索功能，默认true，表示关闭
+            response_format (str, optional): 指定返回的消息格式，默认为text，以文本模式返回。可选 json_object：以json格式返回，可能出现不满足效果情况
+            stop (list[str], optional): 生成停止标识，当模型生成结果以stop中某个元素结尾时，停止文本生成。每个元素长度不超过20字符,最多4个元素.
 
         返回:
             obj:`Message`: 模型运行后的输出消息。
@@ -109,11 +113,13 @@ class Playground(CompletionBaseComponent):
 
         for key in self.variable_names:
             if key not in inputs:
-                raise ValueError(f"Missing input variable {key} in message {message.content}")
+                raise ValueError(
+                    f"Missing input variable {key} in message {message.content}")
 
         prompt = self.prompt_template.format(**inputs)
         query_message = Message(prompt)
-        return super().run(message=query_message, stream=stream, temperature=temperature, top_p=top_p)
+        return super().run(message=query_message, stream=stream, temperature=temperature, top_p=top_p,
+                           max_output_tokens=max_output_tokens, disable_search=disable_search, response_format=response_format, stop=stop)
 
     def __parse__(self, prompt_template):
         last_end = 0
@@ -134,5 +140,3 @@ class Playground(CompletionBaseComponent):
         input_variables = [v for _, v, _, _ in results if v is not None]
 
         return input_variables
-
-

--- a/appbuilder/tests/test_playground.py
+++ b/appbuilder/tests/test_playground.py
@@ -63,6 +63,34 @@ class TestPlayground(unittest.TestCase):
         for ans in answer.content:
             self.assertIsNotNone(ans)
 
+    def test_run_with_max_output_tokens(self):
+        """测试运行时使用参数 max_output_tokens 和 disable_search"""
+        msg = appbuilder.Message({
+            "name": "小明",
+            "bot_name": "机器人",
+            "bot_type": "聊天机器人",
+            "bot_function": "聊天",
+            "bot_question": "2023年北京昌平线地铁出轨事件发生在哪一天？"
+        })
+
+        answer = self.play.run(message=msg, stream=False, temperature=1, max_output_tokens=20, disable_search=False)
+        print(answer)
+        token_usage = answer.token_usage.get("completion_tokens",100)
+        self.assertLessEqual(token_usage, 20)
+    
+    def test_run_with_extra_params(self):
+        """测试运行时使用额外的参数"""
+        msg = appbuilder.Message({
+            "name": "小明",
+            "bot_name": "机器人",
+            "bot_type": "聊天机器人",
+            "bot_function": "聊天",
+            "bot_question": "2023年北京昌平线地铁出轨事件发生在哪一天？"
+        })
+        answer = self.play.run(message=msg, stream=False, temperature=1,system="你是北京市公安局刑事侦查支队的一名警员" )
+        for ans in answer.content:
+            self.assertIsNotNone(ans)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
更新PlayGround 组件的大模型对话可选参数：
- 更新playground.run方法，新增: `max_output_tokens` / `disable_search` / `response_format` / `stop` 参数
- 提供前向兼容方法，未来大模型对话新增参数后，可不更改SDK，在run时，通过kwargs透传参数