### PR TITLE
更新trace功能报错跳过逻辑,完全删掉trace部分报错链路

### DIFF
--- a/appbuilder/tests/test_trace_skip_raise_error.py
+++ b/appbuilder/tests/test_trace_skip_raise_error.py
@@ -133,6 +133,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
         with self.assertRaises(TestException):
             mock_post_02()
 
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
+            mock_post_02()
+
     def test_client_run_trace(self):
         # test_client_run_trace APPBUILDER_TRACE_DEBUG = true
         os.environ["APPBUILDER_TRACE_DEBUG"] = "true"
@@ -143,6 +147,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
         with self.assertRaises(Exception):
             mock_client_run_trace_01()
         with self.assertRaises(TestException):
+            mock_client_run_trace_02()
+
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
             mock_client_run_trace_02()
 
     def test_client_tool_trace(self):
@@ -157,6 +165,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
         with self.assertRaises(TestException):
             mock_client_tool_trace_02()
 
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
+            mock_client_tool_trace_02()
+
     def test_assistent_tool_trace(self):
         # test_assistent_tool_trace APPBUILDER_TRACE_DEBUG = true
         os.environ["APPBUILDER_TRACE_DEBUG"] = "true"
@@ -167,6 +179,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
         with self.assertRaises(Exception):
             mock_assistent_tool_trace_01()
         with self.assertRaises(TestException):
+            mock_assistent_tool_trace_02()
+
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
             mock_assistent_tool_trace_02()
 
     def test_assistant_run_trace(self):
@@ -180,6 +196,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
             mock_assistant_run_trace_01()
         with self.assertRaises(TestException):
             mock_assistant_run_trace_02()
+        
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
+            mock_assistant_run_trace_02()
 
     def test_assistent_stream_run_trace(self):
         # test_assistent_stream_run_trace APPBUILDER_TRACE_DEBUG = true
@@ -191,6 +211,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
         with self.assertRaises(Exception):
             mock_assistent_stream_run_trace_01()
         with self.assertRaises(TestException):
+            mock_assistent_stream_run_trace_02()
+        
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
             mock_assistent_stream_run_trace_02()
 
     def test_assistent_stream_run_with_handler_trace(self):
@@ -205,6 +229,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
         with self.assertRaises(TestException):
             mock_assistent_stream_run_with_handler_trace_02()
 
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
+            mock_assistent_stream_run_with_handler_trace_02()
+
     def test_components_run_trace(self):
         # test_components_run_trace APPBUILDER_TRACE_DEBUG = true
         os.environ["APPBUILDER_TRACE_DEBUG"] = "true"
@@ -215,6 +243,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
         with self.assertRaises(Exception):
             mock_components_run_trace_01()
         with self.assertRaises(TestException):
+            mock_components_run_trace_02()
+
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
             mock_components_run_trace_02()
     
     def test_components_run_stream_trace(self):
@@ -229,6 +261,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
         with self.assertRaises(TestException):
             mock_components_run_stream_trace_02()
 
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
+            mock_components_run_stream_trace_02()
+
     def test_list_trace(self):
         # test_list_trace APPBUILDER_TRACE_DEBUG = true
         os.environ["APPBUILDER_TRACE_DEBUG"] = "true"
@@ -239,6 +275,10 @@ class TestTraceSkipRaiseError(unittest.TestCase):
         with self.assertRaises(Exception):
             mock_list_trace_01()
         with self.assertRaises(TestException):
+            mock_list_trace_02()
+
+        os.environ["APPBUILDER_SDK_TRACE_ENABLE"] = "false"
+        with self.assertRaises(Exception):
             mock_list_trace_02()
 
 

--- a/appbuilder/utils/trace/tracer_wrapper.py
+++ b/appbuilder/utils/trace/tracer_wrapper.py
@@ -14,6 +14,7 @@
 import os
 import sys
 import traceback
+import _testcapi
 from functools import wraps
 
 def _whether_enable_trace():
@@ -93,12 +94,24 @@ def session_post(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
                 
     return wrapper 
 
@@ -141,12 +154,24 @@ def client_run_trace(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
 
     return wrapper 
 
@@ -187,12 +212,24 @@ def client_tool_trace(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
     return wrapper 
 
 
@@ -233,12 +270,24 @@ def assistent_tool_trace(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
     
     return wrapper
 
@@ -279,12 +328,24 @@ def assistant_run_trace(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
     
     return wrapper 
 
@@ -324,12 +385,24 @@ def assistent_stream_run_trace(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
         
     return wrapper 
 
@@ -370,12 +443,24 @@ def assistent_stream_run_with_handler_trace(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
     
     return wrapper 
 
@@ -415,12 +500,24 @@ def components_run_trace(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
                 
     return wrapper
 
@@ -460,12 +557,24 @@ def components_run_stream_trace(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
   
     
     return wrapper
@@ -506,12 +615,24 @@ def list_trace(func):
                     custom_traceback = ''.join(formatted_lines)
                     exception_type = type(e)
                     try:
-                        exception_type("\n"+custom_traceback)
-                    except Exception:
-                        raise e
-                    raise exception_type("\n"+custom_traceback) from None
+                        try:
+                            exception_type('\n'+custom_traceback)
+                        except Exception:
+                            raise e from None
+                        raise exception_type('\n'+custom_traceback) from None
+                    except:
+                        tp, exc, tb = sys.exc_info()
+                        _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                        del tp, exc, tb
+                        raise
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except:
+                tp, exc, tb = sys.exc_info()
+                _testcapi.set_exc_info(tp, exc, tb.tb_next)
+                del tp, exc, tb
+                raise
     
     return wrapper
 


### PR DESCRIPTION
（1）更新trace功能报错跳过逻辑,完全删掉trace部分报错链路
（2）不开启trace功能，直接跳过trace装饰器