### PR TITLE
封装ToolCallEventHandler、AsyncToolCallEventHandler。用户可更方便调用ToolCall，包括MCP。 

### DIFF
--- a/python/core/console/appbuilder_client/async_event_handler.py
+++ b/python/core/console/appbuilder_client/async_event_handler.py
@@ -482,3 +482,79 @@ class AsyncAppBuilderEventHandler(object):
     async def success(self, run_context, run_response):
         # 用户可重载该方法，当event_status为success时，会调用该方法
         pass
+
+
+class AsyncToolCallEventHandler(AsyncAppBuilderEventHandler):
+    def __init__(self, mcp_client, functions):
+        super().__init__()
+        self.mcp_client = mcp_client
+        self.functions = functions
+        self.result = ""
+
+    async def init(
+        self,
+        appbuilder_client,
+        conversation_id,
+        query,
+        file_ids=None,
+        tools=None,
+        stream: bool = False,
+        event_handler=None,
+        action=None,
+        **kwargs
+    ):
+        await super().init(appbuilder_client, conversation_id, query, file_ids, tools, stream, event_handler, action, **kwargs)
+        self.result = ""
+
+    async def reset_state(self):
+        await super().reset_state()
+        self.result = ""
+
+    async def new_dialog(self, query=None, file_ids=None, tools=None, action=None, stream=None, event_handler=None, **kwargs):
+        await super().new_dialog(query, file_ids, tools, action, stream, event_handler, **kwargs)
+        self.result = ""
+
+    async def interrupt(self, run_context, run_response):
+        thought = run_context.current_thought
+        logger.debug("Agent 中间思考: {}\n".format(thought))
+
+        tool_output = []
+        for tool_call in run_context.current_tool_calls:
+            function_name = tool_call.function.name
+            function_arguments = tool_call.function.arguments
+            result = ""
+            function_map = {f.__name__: f for f in self.functions}
+            if function_name in function_map:
+                result = function_map[function_name](
+                    **tool_call.function.arguments)
+                logger.debug("ToolCall结果: {}\n".format(result))
+            else:
+                logger.debug(
+                    "MCP工具名称: {}, MCP参数:{}\n".format(
+                        function_name, function_arguments
+                    )
+                )
+                mcp_server_result = await self.mcp_client.call_tool(
+                    function_name, function_arguments
+                )
+                logger.debug("MCP ToolCall: {}\n".format(mcp_server_result))
+                for i, content in enumerate(mcp_server_result.content):
+                    if content.type == "text":
+                        result = result + mcp_server_result.content[i].text
+            tool_output.append(
+                {
+                    "tool_call_id": tool_call.id,
+                    "output": result,
+                }
+            )
+        return tool_output
+
+    async def running(self, run_context, run_response):
+        if self._stream and run_response.answer and run_response.answer != "":
+            logger.debug("Agent 流式回答: {}".format(run_response.answer))
+            self.result += run_response.answer
+
+    async def success(self, run_context, run_response):
+        if not self._stream:
+            logger.debug("Agent 非流式回答: {}".format(run_response.answer))
+            self.result = run_response.answer

--- a/python/tests/test_appbuilder_client_mcp.py
+++ b/python/tests/test_appbuilder_client_mcp.py
@@ -6,7 +6,7 @@ import subprocess
 import asyncio
 
 from appbuilder.core.console.appbuilder_client.async_event_handler import (
-    AsyncAppBuilderEventHandler,
+    AsyncToolCallEventHandler,
 )
 
 
@@ -22,51 +22,12 @@ from appbuilder.core.console.appbuilder_client.async_event_handler import (
 def get_current_weather(location: str, unit: str) -> str:
     return "北京今天25度"
 
+
 functions = [get_current_weather]
-
-class MyEventHandler(AsyncAppBuilderEventHandler):
-    def __init__(self, mcp_client):
-        super().__init__()
-        self.mcp_client = mcp_client
-
-    async def interrupt(self, run_context, run_response):  
-        thought = run_context.current_thought
-        print("\033[1;31m", "-> Agent 中间思考: ", thought, "\033[0m")
-
-        tool_output = []
-        for tool_call in run_context.current_tool_calls:
-            function_name = tool_call.function.name
-            function_arguments = tool_call.function.arguments
-            result = ""
-            function_map = {f.__name__: f for f in functions}
-            if function_name in function_map:
-                result = function_map[function_name](**tool_call.function.arguments)
-                print("\033[1;33m", "本地function结果: {}\n\033[0m".format(result))
-            else:
-                print("\033[1;32m","MCP工具名称: {}, MCP参数:{}\n".format(function_name, function_arguments),"\033[0m")
-                mcp_server_result = await self.mcp_client.call_tool(
-                    function_name, function_arguments
-                )
-                print("\033[1;33m", "MCP结果: {}\n\033[0m".format(mcp_server_result))
-                index = 0
-                for i, content in enumerate(mcp_server_result.content):
-                    if content.type == "text":
-                        index = i
-                        result = result + mcp_server_result.content[index].text    
-            tool_output.append(
-                {
-                    "tool_call_id": tool_call.id,
-                    "output": result,
-                }
-            )
-        return tool_output
-
-    async def success(self, run_context, run_response):
-        print("\n\033[1;34m", "-> Agent 非流式回答: ", run_response.answer, "\033[0m")
 
 
 @unittest.skipUnless(os.getenv("TEST_CASE", "UNKNOWN") == "CPU_SERIAL", "")
-class TestAgentRuntime(unittest.TestCase):
+class TestAppBuilderClientMCP(unittest.TestCase):
     def setUp(self):
         """
         设置环境变量。
@@ -93,40 +54,45 @@ class TestAgentRuntime(unittest.TestCase):
             unittest.SkipTest (optional): 如果app_id为空，则跳过单测执行
         """
 
-        async def agent_run(client, mcp_client, query):
-            conversation_id = await client.create_conversation()
+        async def process():
             tools = [appbuilder.Manifest.from_function(f) for f in functions]
+            mcp_client = MCPClient()
+            await mcp_client.connect_to_server("./data/mcp_component_server_sample.py")
             tools.extend(mcp_client.tools)
-            with await client.run_with_handler(
+
+            appbuilder_client = appbuilder.AsyncAppBuilderClient(self.app_id)
+            conversation_id = await appbuilder_client.create_conversation()
+
+            event_handler = AsyncToolCallEventHandler(
+                mcp_client, functions=functions)
+            with await appbuilder_client.run_with_handler(
                 conversation_id=conversation_id,
-                query=query,
+                query="北京的天气怎么样",
                 tools=tools,
-                event_handler=MyEventHandler(mcp_client),
+                event_handler=event_handler,
+                stream=False,
             ) as run:
                 await run.until_done()
 
-        async def handler():
-            mcp_client = MCPClient()
-            appbuilder_client = appbuilder.AsyncAppBuilderClient(self.app_id)
-            try:
-                await mcp_client.connect_to_server(
-                    "./data/mcp_official_server_sample.py"
-                )
-                await agent_run(appbuilder_client, mcp_client, "北京的天气怎么样")
-                await agent_run(appbuilder_client, mcp_client, "美国马萨诸塞州的天气")
-            finally:
-                await appbuilder_client.http_client.session.close()
-                await mcp_client.cleanup()
+            with await appbuilder_client.run_with_handler(
+                conversation_id=conversation_id,
+                query="翻译hello world为中文",
+                tools=tools,
+                event_handler=event_handler,
+                stream=True,
+            ) as run:
+                await run.until_done()
+            
 
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "uninstall", "-y", "chainlit"]
-        )
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "mcp"])
+            await appbuilder_client.http_client.session.close()
+            await mcp_client.cleanup()
+
         from appbuilder.modelcontextprotocol.client import MCPClient
-
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "mcp"])
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(handler())
+        loop.run_until_complete(process())
 
 
 if __name__ == "__main__":
+    appbuilder.logger.setLoglevel("DEBUG")
     unittest.main()


### PR DESCRIPTION
(1) mcp tools可以跟原来的tools一起作为参数传进去。
(2) 封装toolcall调用，用户不用关心toolcall调用细节。mcp tool和原来的tool都可以自动化调用。
(3)现在用户不用自己复制我们的MyEventHandler模板，直接调用ToolCallEventHandler即可。